### PR TITLE
修改openlist二进制文件路径提供方式

### DIFF
--- a/OpenList-Magisk/action.sh
+++ b/OpenList-Magisk/action.sh
@@ -9,11 +9,11 @@ OPLISTDIR="/data/adb/openlist/bin" "$MODDIR/bin" "/system/bin"
 REPO_URL="https://github.com/Alien-Et/OpenList-Magisk"
 
 check_openlist_status() {
-  if result=$(find $OPLISTDIR -name "openlist" 2>/dev/null); then
-     pgrep -f "$result server" >/dev/null && return 0;
-	 else
-	    return 1
-	 fi
+    if result=$(find $OPLISTDIR -name "openlist" 2>/dev/null); then
+        pgrep -f "$result server" >/dev/null && return 0;
+    else
+        return 1
+    fi
 }
 
 update_module_prop_stopped() {


### PR DESCRIPTION
使用find命令查找openlist二进制文件并把完整路径提交给pgrep命令，使脚本可以正常检测openlist运行pid